### PR TITLE
Implement docker image CICD

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,54 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PLATFORMS: linux/amd64
+
+
+    steps:
+    -
+        name: Checkout
+        uses: actions/checkout@v3
+    -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+    -
+        name: setup docker buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+    -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+    - 
+      name: Build the Docker image
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64 -t onemorebsmith/kaspa-stratum-bridge:latest --progress=plain --push .
+    -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: onemorebsmith/kaspa-stratum-bridge:latest
+          
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_TOKEN }}
+
+    - name: Build the onemorebsmith/kaspa-stratum-bridge:latest Docker image for Github Registry
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64 -t ghcr.io/onemorebsmith/kaspa-stratum-bridge:latest --progress=plain --push .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.18 as builder
 
-
+LABEL org.opencontainers.image.description="Dockerized Kaspa Stratum Bridge"      
+LABEL org.opencontainers.image.authors="onemorebsmith"  
+LABEL org.opencontainers.image.source="https://github.com/onemorebsmith/kaspa-stratum-bridge"
+              
 WORKDIR /go/src/app
 ADD go.mod .
 ADD go.sum .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.19.1 as builder
 
 LABEL org.opencontainers.image.description="Dockerized Kaspa Stratum Bridge"      
 LABEL org.opencontainers.image.authors="onemorebsmith"  


### PR DESCRIPTION
Automatically generates new docker image on push to main branch and posts it to both the dockerhub and github image repositories. 
Requires that @onemorebsmith implement 3 github secrets for the repo:
- DOCKER_USERNAME
  - Your dockerhub username 
- DOCKER_PASSWORD
  - A token generated from the dockerhub account page
- PAT_TOKEN
  - A PAT token for your github account

Documentation:
https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces
https://docs.docker.com/docker-hub/access-tokens/
https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
